### PR TITLE
Initialize API

### DIFF
--- a/src/Utils/client.js
+++ b/src/Utils/client.js
@@ -18,10 +18,7 @@ const pruneSprites = (spritesData) => {
   const prunedData = {};
 
   // this field seemed suspect so this is a cautious measure
-  if (
-    spritesData["other"] !== undefined &&
-    spritesData["other"]["official-artwork"] !== undefined
-  ) {
+  if (spritesData["other"] && spritesData["other"]["official-artwork"]) {
     prunedData.large =
       spritesData["other"]["official-artwork"]["front_default"];
   }
@@ -48,7 +45,7 @@ const prunePokemon = (pokemonData) => {
 
 export const findPokemon = async (name) => {
   const response = await axios.get(`${API_BASE}/pokemon/${name}`);
-  if (response.data === undefined) {
+  if (!response.data) {
     return undefined;
   }
 

--- a/src/Utils/client.js
+++ b/src/Utils/client.js
@@ -65,7 +65,6 @@ export const searchPokemonBySubstring = async (substring) => {
   const allPokemon = response.data.results;
   const filteredPokemon = allPokemon
     .filter((pokemon) => pokemon.name.includes(substring.toLowerCase())) // has search query in name
-    .filter((pokemon) => !pokemon.name.includes("-")) // no mega types
     .map((pokemon) => pokemon.name);
 
   return filteredPokemon;

--- a/src/Utils/client.js
+++ b/src/Utils/client.js
@@ -1,0 +1,72 @@
+import axios from "axios";
+const API_BASE = "https://pokeapi.co/api/v2";
+const POKEMON_TOTAL = 1292; // setting limit for "all pokemon" query
+
+/////////////
+// HELPERS //
+/////////////
+
+/////////////
+// PRUNING // (since we don't want thaaaat much data)
+/////////////
+
+const pruneTypes = (typesData) => {
+  return typesData.map((t) => t.type.name);
+};
+
+const pruneSprites = (spritesData) => {
+  const prunedData = {};
+
+  // this field seemed suspect so this is a cautious measure
+  if (
+    spritesData["other"] !== undefined &&
+    spritesData["other"]["official-artwork"] !== undefined
+  ) {
+    prunedData.large =
+      spritesData["other"]["official-artwork"]["front_default"];
+  }
+  prunedData.small = spritesData["front_default"];
+
+  return prunedData;
+};
+
+const prunePokemon = (pokemonData) => {
+  const prunedData = {};
+  prunedData.id = pokemonData.id;
+  prunedData.name = pokemonData.name;
+  prunedData.height = parseInt(pokemonData.height) / 10; // decimeters -> meters
+  prunedData.weight = parseInt(pokemonData.weight) / 10; // hectograms -> kilograms
+  prunedData.types = pruneTypes(pokemonData.types);
+  prunedData.sprites = pruneSprites(pokemonData.sprites);
+
+  return prunedData;
+};
+
+/////////////
+// EXPORTS //
+/////////////
+
+export const findPokemon = async (name) => {
+  const response = await axios.get(`${API_BASE}/pokemon/${name}`);
+  if (response.data === undefined) {
+    return undefined;
+  }
+
+  return prunePokemon(response.data);
+};
+
+// GET: list of Pokemon names (not full Pokemon data)
+// not case-sensitive
+export const searchPokemonBySubstring = async (substring) => {
+  const response = await axios.get(
+    `${API_BASE}/pokemon?limit=${POKEMON_TOTAL}`
+  ); // all pokemon
+
+  const allPokemon = response.data.results;
+  const filteredPokemon = allPokemon
+    .filter((pokemon) => pokemon.name.includes(substring.toLowerCase())) // has search query in name
+    .filter((pokemon) => !pokemon.name.includes("-")) // no mega types
+    .map((pokemon) => pokemon.name);
+
+  return filteredPokemon;
+};


### PR DESCRIPTION
Implements functionality to:
- Get the data for a specific Pokemon based on its name
- Get all the Pokemon names that fit the search query (i.e. query is a substring of the name)

This is what I used to spot check that it worked:
```jsx
    const [response, setResponse] = useState({});
    useEffect(() => {
        findPokemon("pichu").then(
            (pokemon) => {
                setResponse(pokemon);
            }
        );
    }, []);

    return <h1>{JSON.stringify(response)}</h1>
```

I replaced `findPokemon()` with a `searchPokemonBySubstring()` call to test as well. Any suggestions on what to include in the pruned data are welcome. 

[Documentation for find()](https://pokeapi.co/docs/v2#pokemon)
[API playground](https://pokeapi.co/)